### PR TITLE
Implement undervoltage lockout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,6 +276,7 @@ target_compile_options(pcbv2_front.elf PRIVATE
         #    -DCAN_LOG_UNKNOWN_ADDR
         #     -DIS_BACK
         -DAMPERE2BIT_CONV=28
+        -DFEATURE_UVLO
 )
 add_custom_command(OUTPUT pcbv2_front.hex COMMAND arm-none-eabi-objcopy -O ihex pcbv2_front.elf pcbv2_front.hex DEPENDS pcbv2_front.elf)
 add_custom_command(OUTPUT pcbv2_front.bin COMMAND arm-none-eabi-objcopy -O binary -S pcbv2_front.elf pcbv2_front.bin DEPENDS pcbv2_front.elf)
@@ -303,6 +304,7 @@ target_compile_options(pcbv2_back.elf PRIVATE
         #    -DCAN_LOG_UNKNOWN_ADDR
         -DIS_BACK
         -DAMPERE2BIT_CONV=28
+        -DFEATURE_UVLO
 )
 add_custom_command(OUTPUT pcbv2_back.hex COMMAND arm-none-eabi-objcopy -O ihex pcbv2_back.elf pcbv2_back.hex DEPENDS pcbv2_back.elf)
 add_custom_command(OUTPUT pcbv2_back.bin COMMAND arm-none-eabi-objcopy -O binary -S pcbv2_back.elf pcbv2_back.bin DEPENDS pcbv2_back.elf)

--- a/uvlo.h
+++ b/uvlo.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "config.h"
+
+namespace UVLO
+{
+static constexpr uint32_t NUM_MEASUREMENTS = 50;
+static constexpr uint32_t MIN_VOLTAGE = 1500 * BAT_CALIB_ADC / BAT_CALIB_REAL_VOLTAGE;
+
+static uint32_t measurements = 0;
+static uint32_t sum = 0;
+static bool locked_out = true;
+
+static void update(uint16_t voltage)
+{
+    if (measurements < NUM_MEASUREMENTS)
+    {
+        sum += voltage;
+        measurements++;
+
+        if (measurements == NUM_MEASUREMENTS && sum / NUM_MEASUREMENTS >= MIN_VOLTAGE)
+            locked_out = false;
+    }
+}
+
+static bool isDone()
+{
+    return measurements >= NUM_MEASUREMENTS;
+}
+
+static bool isLockedOut()
+{
+    return locked_out;
+}
+
+} // namespace


### PR DESCRIPTION
This leaves MOSFETs disabled if the voltage on boot is less than about 20 V. This should allow for easier pushing of broken bobby cars. Fixes #16.